### PR TITLE
Update go.mod with /v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/scim2/filter-parser
+module github.com/scim2/filter-parser/v2
 
 go 1.15
 


### PR DESCRIPTION
Hello! This PR adds a /v2 module path, so that other projects can use the v2.x releases.
Regards