### PR TITLE
fix: allow hyphens in URI segments

### DIFF
--- a/attrpath_test.go
+++ b/attrpath_test.go
@@ -7,3 +7,9 @@ func ExampleParseAttrPath() {
 	// Output:
 	// urn:ietf:params:scim:schemas:core:2.0:User:name.familyName <nil>
 }
+
+func ExampleParseAttrPath_dash() {
+	fmt.Println(ParseAttrPath([]byte("urn:example:scim:schemas:extension:my-custom-ext:1.0:User:name.familyName")))
+	// Output:
+	// urn:example:scim:schemas:extension:my-custom-ext:1.0:User:name.familyName <nil>
+}

--- a/flake.nix
+++ b/flake.nix
@@ -12,12 +12,26 @@
       devShells = forAllSystems (system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
+          ci = pkgs.writeShellScriptBin "ci" ''
+            set -euo pipefail
+            echo "--- test ---"
+            go test -v ./...
+            echo "--- lint ---"
+            golangci-lint run -E misspell,godot,whitespace ./...
+            echo "--- arrange ---"
+            command -v goarrange >/dev/null || go install github.com/jdeflander/goarrange@v1.0.0
+            test -z "$(goarrange run -r -d)"
+            echo "--- tidy ---"
+            go mod tidy
+            git diff --quiet go.mod go.sum
+          '';
         in
         {
           default = pkgs.mkShell {
             packages = [
               pkgs.go_1_26
               pkgs.golangci-lint
+              ci
             ];
           };
         }

--- a/internal/grammar/uri.go
+++ b/internal/grammar/uri.go
@@ -7,6 +7,15 @@ import (
 	"github.com/scim2/filter-parser/v2/internal/types"
 )
 
+// URI parses a URN as defined in RFC 8141 Section 2.
+// https://datatracker.ietf.org/doc/html/rfc8141#section-2
+//
+// Each segment between colons may contain alphanumeric characters,
+// hyphens, and periods:
+//   - NID allows alphanum and "-" (ldh production).
+//   - NSS allows pchar (RFC 3986), which includes unreserved chars
+//     (ALPHA / DIGIT / "-" / "." / "_" / "~"), but in practice SCIM
+//     schema URNs only use alphanum, "-", and ".".
 func URI(p *ast.Parser) (*ast.Node, error) {
 	return p.Expect(ast.Capture{
 		Type:        typ.URI,
@@ -16,6 +25,7 @@ func URI(p *ast.Parser) (*ast.Node, error) {
 				parser.CheckRuneRange('a', 'z'),
 				parser.CheckRuneRange('A', 'Z'),
 				parser.CheckRuneRange('0', '9'),
+				'-',
 				'.',
 			}),
 			":",

--- a/internal/grammar/uri_test.go
+++ b/internal/grammar/uri_test.go
@@ -11,3 +11,10 @@ func ExampleURI() {
 	// Output:
 	// ["URI","urn:ietf:params:scim:schemas:core:2.0:User:"] <nil>
 }
+
+func ExampleURI_dash() {
+	p, _ := ast.New([]byte("urn:example:scim:schemas:extension:my-custom-ext:1.0:User:userName"))
+	fmt.Println(URI(p))
+	// Output:
+	// ["URI","urn:example:scim:schemas:extension:my-custom-ext:1.0:User:"] <nil>
+}


### PR DESCRIPTION
The URI parser only accepted [a-zA-Z0-9.] in segments between colons,
rejecting valid URNs containing hyphens (e.g. custom extension URIs
like urn:example:scim:schemas:extension:my-custom-ext:1.0:User).

Add "-" to the allowed character set per RFC 8141 Section 2, which
defines the NID production as alphanum / "-" (ldh).

Fixes #25 